### PR TITLE
missing setuptools package on bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ fi
 if [[ $EUID == 0 ]]; then
   apt update
   apt install --no-install-recommends -y \
-    git build-essential wget python-pip curl autoconf automake libtool unzip pkg-config ca-certificates nasm
+    git build-essential wget python-pip python-setuptools curl autoconf automake libtool unzip pkg-config ca-certificates nasm
 
   invalid_cmake_version=false
   if command -v cmake > /dev/null ; then 


### PR DESCRIPTION
Got error below when tried to run bootstrap.sh on a docker ubuntu:16.04 image.

`Collecting conan_package_tools`
`  Downloading`
`https://files.pythonhosted.org/packages/49/65/8ba52416da4bde7603ca89b770f00ee6ec96661e5c6514a7679ab15fae4a/conan_package_tools-0.17.1.tar.gz (41kB)`
`    Complete output from command python setup.py egg_info:`
`    Traceback (most recent call last):`
`      File "<string>", line 1, in <module>`
`    ImportError: No module named setuptools`

Just add the package python-setuptools on `apt install` command.