### PR TITLE
Add file reader and writer for protobuf messages

### DIFF
--- a/is/utils/io.cpp
+++ b/is/utils/io.cpp
@@ -1,13 +1,15 @@
 #include "io.hpp"
-#include <fstream>
 #include "boost/filesystem.hpp"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/json_util.h"
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "spdlog/fmt/fmt.h"
 
 namespace is {
 
 namespace fs = boost::filesystem;
+namespace gio = google::protobuf::io;
 
 wire::Status load(std::string const& filename, google::protobuf::Message* message) {
   auto path = fs::path{filename};
@@ -66,6 +68,38 @@ wire::Status save(std::string const& filename, google::protobuf::Message const& 
   file << data;
   file.close();
   return make_status(wire::StatusCode::OK);
+}
+
+ProtobufWriter::ProtobufWriter(std::string const &filename)
+    : file(filename, std::ios::out | std::ios::binary) {
+  raw_output = new gio::OstreamOutputStream(&file);
+  coded_output = new gio::CodedOutputStream(raw_output);
+}
+
+ProtobufWriter::~ProtobufWriter() { this->close(); }
+
+void ProtobufWriter::close() {
+  if (file.is_open()) {
+    delete coded_output;
+    delete raw_output;
+    file.close();
+  }
+}
+
+ProtobufReader::ProtobufReader(std::string const &filename)
+    : file(filename, std::ios::in | std::ios::binary) {
+  raw_input = new gio::IstreamInputStream(&file);
+  coded_input = new gio::CodedInputStream(raw_input);
+}
+
+ProtobufReader::~ProtobufReader() { this->close(); }
+
+void ProtobufReader::close() {
+  if (file.is_open()) {
+    delete coded_input;
+    delete raw_input;
+    file.close();
+  }
 }
 
 }  // namespace is

--- a/is/utils/io.cpp
+++ b/is/utils/io.cpp
@@ -2,8 +2,6 @@
 #include "boost/filesystem.hpp"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/json_util.h"
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "spdlog/fmt/fmt.h"
 
 namespace is {
@@ -70,33 +68,84 @@ wire::Status save(std::string const& filename, google::protobuf::Message const& 
   return make_status(wire::StatusCode::OK);
 }
 
-ProtobufWriter::ProtobufWriter(std::string const &filename)
+ProtobufWriter::ProtobufWriter(std::string const& filename) try
     : file(filename, std::ios::out | std::ios::binary) {
-  raw_output = new gio::OstreamOutputStream(&file);
-  coded_output = new gio::CodedOutputStream(raw_output);
+  this->raw_output = new gio::OstreamOutputStream(&file);
+} catch (std::exception const& e) {
+  auto why = fmt::format("Can't open file \'{}\'\n{}", filename, e.what());
+  throw make_status(wire::StatusCode::FAILED_PRECONDITION, why);
 }
 
-ProtobufWriter::~ProtobufWriter() { this->close(); }
+ProtobufWriter::~ProtobufWriter() {
+  this->close();
+}
+
+wire::Status ProtobufWriter::insert(google::protobuf::Message const& message) {
+  auto size = message.ByteSize();
+  // We create a new coded stream for each message.  Don't worry, this is fast.
+  google::protobuf::io::CodedOutputStream coded_output(this->raw_output);
+  coded_output.WriteVarint32(size);
+  uint8_t* buffer = coded_output.GetDirectBufferForNBytesAndAdvance(size);
+  if (buffer != nullptr) {
+    // Optimization:  The message fits in one buffer, so use the faster
+    // direct-to-array serialization path.
+    message.SerializeWithCachedSizesToArray(buffer);
+  } else {
+    // Slightly-slower path when the message is multiple buffers.
+    message.SerializeWithCachedSizes(&coded_output);
+    if (coded_output.HadError()) {
+      auto why = "Can not write serialized message on buffer.";
+      return make_status(wire::StatusCode::INTERNAL_ERROR, why);
+    }
+  }
+  return make_status(wire::StatusCode::OK);
+}
 
 void ProtobufWriter::close() {
   if (file.is_open()) {
-    delete coded_output;
     delete raw_output;
     file.close();
   }
 }
 
-ProtobufReader::ProtobufReader(std::string const &filename)
+ProtobufReader::ProtobufReader(std::string const& filename) try
     : file(filename, std::ios::in | std::ios::binary) {
   raw_input = new gio::IstreamInputStream(&file);
-  coded_input = new gio::CodedInputStream(raw_input);
+} catch (std::exception const& e) {
+  auto why = fmt::format("Can't open file \'{}\'\n{}", filename, e.what());
+  throw make_status(wire::StatusCode::FAILED_PRECONDITION, why);
 }
 
-ProtobufReader::~ProtobufReader() { this->close(); }
+ProtobufReader::~ProtobufReader() {
+  this->close();
+}
+
+wire::Status ProtobufReader::next(google::protobuf::Message* message) {
+  // We create a new coded stream for each message.  Don't worry, this is fast,
+  // and it makes sure the 64MB total size limit is imposed per-message rather
+  // than on the whole stream.  (See the CodedInputStream interface for more
+  // info on this limit.)
+  google::protobuf::io::CodedInputStream coded_input(this->raw_input);
+
+  uint32_t size;
+  if (!coded_input.ReadVarint32(&size)) {
+    this->close();
+    return make_status(wire::StatusCode::OUT_OF_RANGE, "End of file");
+  }
+  // Tell the stream not to read beyond that size.
+  google::protobuf::io::CodedInputStream::Limit msg_limit = coded_input.PushLimit(size);
+  if (!message->MergeFromCodedStream(&coded_input)) {
+    return make_status(wire::StatusCode::INTERNAL_ERROR, "Can't deserialize message");
+  } else if (!coded_input.ConsumedEntireMessage()) {
+    return make_status(wire::StatusCode::INTERNAL_ERROR, "");
+  }
+  // Release the limit
+  coded_input.PopLimit(msg_limit);
+  return make_status(wire::StatusCode::OK);
+}
 
 void ProtobufReader::close() {
   if (file.is_open()) {
-    delete coded_input;
     delete raw_input;
     file.close();
   }

--- a/is/utils/io.hpp
+++ b/is/utils/io.hpp
@@ -1,10 +1,64 @@
 #pragma once
 
 #include <string>
+#include <fstream>
 #include "google/protobuf/message.h"
 #include "status.hpp"
+#include "boost/optional.hpp"
+
+namespace google {
+namespace protobuf {
+namespace io {
+class ZeroCopyOutputStream;
+class CodedOutputStream;
+class CodedInputStream;
+}
+}
+}
 
 namespace is {
 wire::Status load(std::string const& filename, google::protobuf::Message* message);
 wire::Status save(std::string const& filename, google::protobuf::Message const& message);
+
+struct ProtobufWriter {
+  std::ofstream file;
+  google::protobuf::io::ZeroCopyOutputStream *raw_output;
+  google::protobuf::io::CodedOutputStream *coded_output;
+
+  ProtobufWriter(std::string const &filename);
+  ~ProtobufWriter();
+  void close();
+
+  template <typename T> bool insert(T const &message) {
+    coded_output->WriteVarint32(message.ByteSize());
+    return message.SerializeToCodedStream(coded_output);
+  }
+};
+
+struct ProtobufReader {
+  std::ifstream file;
+  google::protobuf::io::ZeroCopyInputStream *raw_input;
+  google::protobuf::io::CodedInputStream *coded_input;
+
+  ProtobufReader(std::string const &filename);
+  ~ProtobufReader();
+  void close();
+
+  template <typename T> boost::optional<T> next() {
+    boost::optional<T> optional;
+    uint32_t size;
+    if (!coded_input->ReadVarint32(&size)) {
+      this->close();
+      return optional;
+    }
+    google::protobuf::io::CodedInputStream::Limit msg_limit = coded_input->PushLimit(size);
+    T msg;
+    if (msg.ParseFromCodedStream(coded_input)) {
+      coded_input->PopLimit(msg_limit);
+      optional = msg;
+    }
+    return optional;
+  }
+};
+
 }  // namespace is

--- a/is/utils/io.hpp
+++ b/is/utils/io.hpp
@@ -1,64 +1,41 @@
 #pragma once
 
-#include <string>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <fstream>
+#include <memory>
+#include <string>
+#include "boost/optional.hpp"
 #include "google/protobuf/message.h"
 #include "status.hpp"
-#include "boost/optional.hpp"
-
-namespace google {
-namespace protobuf {
-namespace io {
-class ZeroCopyOutputStream;
-class CodedOutputStream;
-class CodedInputStream;
-}
-}
-}
 
 namespace is {
 wire::Status load(std::string const& filename, google::protobuf::Message* message);
 wire::Status save(std::string const& filename, google::protobuf::Message const& message);
 
+/*
+  Implementation of 'ProtobufWriter' and 'ProtobufReader' based on
+  https://stackoverflow.com/questions/2340730/are-there-c-equivalents-for-the-protocol-buffers-delimited-i-o-functions-in-ja
+*/
+
 struct ProtobufWriter {
   std::ofstream file;
-  google::protobuf::io::ZeroCopyOutputStream *raw_output;
-  google::protobuf::io::CodedOutputStream *coded_output;
+  google::protobuf::io::ZeroCopyOutputStream* raw_output;
 
-  ProtobufWriter(std::string const &filename);
+  ProtobufWriter(std::string const& filename);
   ~ProtobufWriter();
+  wire::Status insert(google::protobuf::Message const& message);
   void close();
-
-  template <typename T> bool insert(T const &message) {
-    coded_output->WriteVarint32(message.ByteSize());
-    return message.SerializeToCodedStream(coded_output);
-  }
 };
 
 struct ProtobufReader {
   std::ifstream file;
-  google::protobuf::io::ZeroCopyInputStream *raw_input;
-  google::protobuf::io::CodedInputStream *coded_input;
+  google::protobuf::io::ZeroCopyInputStream* raw_input;
 
-  ProtobufReader(std::string const &filename);
+  ProtobufReader(std::string const& filename);
   ~ProtobufReader();
+  wire::Status next(google::protobuf::Message* message);
   void close();
-
-  template <typename T> boost::optional<T> next() {
-    boost::optional<T> optional;
-    uint32_t size;
-    if (!coded_input->ReadVarint32(&size)) {
-      this->close();
-      return optional;
-    }
-    google::protobuf::io::CodedInputStream::Limit msg_limit = coded_input->PushLimit(size);
-    T msg;
-    if (msg.ParseFromCodedStream(coded_input)) {
-      coded_input->PopLimit(msg_limit);
-      optional = msg;
-    }
-    return optional;
-  }
 };
 
 }  // namespace is


### PR DESCRIPTION
Some stuff can be done to improve, e.g.:
- return an error code (is::wire::Status) when file can't be opened in both _ProtobufReader_ and _ProtobufWriter_
- maybe, on _ProtobufReader::next_, returns is::wire::Status and pass a reference to desired message, as well as in _ProtobufReader::insert_ method
- if it's possible, return an error code on _ProtobufReader::next_ when isn't possible to desarealize the message for the given schema 

I'm open for discuss the modelling of these features!